### PR TITLE
Gestion du blocage par logiciel métier lors sauvegarde

### DIFF
--- a/EasyConsole/View/Commands/ExecuteBackupJobCommand.cs
+++ b/EasyConsole/View/Commands/ExecuteBackupJobCommand.cs
@@ -25,9 +25,13 @@ namespace EasyConsole.View.Commands
 			{
 				if (id > 0)
 				{
-					BackupManager.GetBM().ExecuteJob(id, ConsoleView.DisplayProgress);
-					Console.WriteLine(I18n.Instance.GetString("execute_success"));
-				}
+                    bool success = BackupManager.GetBM().ExecuteJob(id, ConsoleView.DisplayProgress);
+
+                    if (success)
+                    {
+                        Console.WriteLine(I18n.Instance.GetString("execute_success"));
+                    }
+                }
 			}
 			catch (Exception e)
 			{

--- a/EasyConsole/View/ConsoleView.cs
+++ b/EasyConsole/View/ConsoleView.cs
@@ -131,7 +131,15 @@ namespace EasyConsole.View
 
 		public static void DisplayProgress(ProgressState state)
 		{
-			Console.WriteLine($"\n{I18n.Instance.GetString("progress_active")}");
+            if (!string.IsNullOrEmpty(state.Message))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"\n >> {state.Message}");
+                Console.ResetColor();
+                if (state.State == State.Error) return;
+            }
+
+            Console.WriteLine($"\n{I18n.Instance.GetString("progress_active")}");
 			Console.WriteLine(string.Format(I18n.Instance.GetString("progress_files"), 
 				state.TotalFiles - state.FilesRemaining, state.TotalFiles));
 			Console.WriteLine(string.Format(I18n.Instance.GetString("progress_size"), 

--- a/EasySave/Backup/BackupJob.cs
+++ b/EasySave/Backup/BackupJob.cs
@@ -42,11 +42,16 @@ namespace EasySave.Backup
 		/// <param name="progressCallback">A callback method that receives progress updates as a <see cref="ProgressState"/> object. Cannot be null.</param>
 		public void Execute(Action<ProgressState> progressCallback)
 		{
+			string BusinessSoftware = BackupManager.GetBM().ConfigManager.GetConfig("BusinessSoftware");
 			State = State.Active;
-			Strategy.Execute(this, progressCallback);
-			LastExecution = DateTime.Now;
-			State = State.Completed;
-		}
+            Strategy.Execute(this, BusinessSoftware, progressCallback);
+
+            if (State != State.Error)
+            {
+                LastExecution = DateTime.Now;
+                State = State.Completed;
+            }
+        }
 
 		/// <summary>
 		/// Transitions the current state to indicate an error has occurred.	

--- a/EasySave/Backup/BackupManager.cs
+++ b/EasySave/Backup/BackupManager.cs
@@ -154,14 +154,16 @@ namespace EasySave.Backup
 		/// <param name="progressCallback">An optional callback that receives progress updates during job execution. If null, progress updates are not
 		/// reported.</param>
 		/// <exception cref="ArgumentException">Thrown if a backup job with the specified ID does not exist.</exception>
-		public void ExecuteJob(int id, Action<ProgressState>? progressCallback = null)
+		public bool ExecuteJob(int id, Action<ProgressState>? progressCallback = null)
 		{
 			var job = _backupJobs.FirstOrDefault(j => j.Id == id);
 			if (job == null)
 				throw new ArgumentException($"Backup job with ID {id} not found.");
 
 			ExecuteSingleJob(job, progressCallback);
-		}
+
+            return job.State != State.Error;
+        }
 
 		/// <summary>
 		/// Executes all backup jobs with IDs in the specified inclusive range, optionally reporting progress for each job.

--- a/EasySave/Backup/CompleteBackupStrategy.cs
+++ b/EasySave/Backup/CompleteBackupStrategy.cs
@@ -21,7 +21,7 @@ namespace EasySave.Backup
 		/// <param name="progressCallback">A callback method that receives progress updates as the backup operation proceeds. Can be null if progress
 		/// reporting is not required.</param>
 		/// <exception cref="DirectoryNotFoundException">Thrown if the source directory specified in the backup job does not exist.</exception>
-		public void Execute(BackupJob job, Action<ProgressState> progressCallback)
+		public void Execute(BackupJob job, string BusinessSoftware, Action<ProgressState> progressCallback)
 		{
 			if (!Directory.Exists(job.SourceDirectory))
 			{
@@ -42,12 +42,53 @@ namespace EasySave.Backup
 				totalSize += fileInfo.Length;
 			}
 
-			int processedFiles = 0;
+            if (!string.IsNullOrEmpty(BusinessSoftware) && Process.GetProcessesByName(BusinessSoftware).Length > 0)
+            {
+                string msg = $"[BLOCK] Logiciel métier détecté : '{BusinessSoftware}'. Sauvegarde annulée.";
+                BackupManager.GetLogger().Log(new LogEntry
+                {
+                    Level = Level.Warning,
+                    Message = $"Backup {job.Name} aborted: Business software '{BusinessSoftware}' is running."
+                });
+
+                job.State = State.Error;
+                progressCallback?.Invoke(new ProgressState
+                {
+                    BackupName = job.Name,
+                    State = State.Error,
+                    Message = msg
+                });
+
+                return;
+            }
+
+            int processedFiles = 0;
 			long processedSize = 0;
 
 			foreach (var sourceFile in files)
 			{
-				var relativePath = Path.GetRelativePath(job.SourceDirectory, sourceFile);
+                if (!string.IsNullOrEmpty(BusinessSoftware) && Process.GetProcessesByName(BusinessSoftware).Length > 0)
+                {
+                    string msg = $"[STOP] Logiciel métier détecté : '{BusinessSoftware}'. Sauvegarde interrompue.";
+                    BackupManager.GetLogger().Log(new LogEntry
+                    {
+                        Level = Level.Warning,
+                        Message = $"Backup {job.Name} stopped: Business software '{BusinessSoftware}' detected during execution."
+                    });
+
+                    job.State = State.Error;
+
+                    progressCallback?.Invoke(new ProgressState
+                    {
+                        BackupName = job.Name,
+                        State = State.Error,
+                        Message = msg
+                    });
+
+                    break;
+                }
+
+                var relativePath = Path.GetRelativePath(job.SourceDirectory, sourceFile);
 				var targetFile = Path.Combine(job.TargetDirectory, relativePath);
 				var targetDir = Path.GetDirectoryName(targetFile);
 
@@ -101,18 +142,20 @@ namespace EasySave.Backup
 			}
 
 			// Final progress state
-			var finalState = new ProgressState
+			if (job.State != State.Error)
 			{
-				BackupName = job.Name,
-				State = State.Completed,
-				TotalFiles = totalFiles,
-				TotalSize = totalSize,
-				FilesRemaining = 0,
-				SizeRemaining = 0,
-				ProgressPercentage = 100
-			};
-
-			progressCallback?.Invoke(finalState);
+				var finalState = new ProgressState
+				{
+					BackupName = job.Name,
+					State = State.Completed,
+					TotalFiles = totalFiles,
+					TotalSize = totalSize,
+					FilesRemaining = 0,
+					SizeRemaining = 0,
+					ProgressPercentage = 100
+				};
+                progressCallback?.Invoke(finalState);
+            }
 		}
 	}
 }

--- a/EasySave/Backup/DifferentialBackupStrategy.cs
+++ b/EasySave/Backup/DifferentialBackupStrategy.cs
@@ -23,7 +23,7 @@ namespace EasySave.Backup
 		/// cref="ProgressState"/> object representing the current state of the backup. Can be <see langword="null"/> if
 		/// progress updates are not required.</param>
 		/// <exception cref="DirectoryNotFoundException">Thrown if the source directory specified in <paramref name="job"/> does not exist.</exception>
-		public void Execute(BackupJob job, Action<ProgressState> progressCallback)
+		public void Execute(BackupJob job, string BusinessSoftware, Action<ProgressState> progressCallback)
 		{
 			if (!Directory.Exists(job.SourceDirectory))
 			{
@@ -44,13 +44,42 @@ namespace EasySave.Backup
 				totalSize += fileInfo.Length;
 			}
 
-			int processedFiles = 0;
+            if (!string.IsNullOrEmpty(BusinessSoftware) && Process.GetProcessesByName(BusinessSoftware).Length > 0)
+            {
+                string msg = $"[BLOCK] Logiciel métier détecté : '{BusinessSoftware}'. Sauvegarde annulée.";
+                BackupManager.GetLogger().Log(new LogEntry
+                {
+                    Level = Level.Warning,
+                    Message = $"Backup {job.Name} aborted: Business software '{BusinessSoftware}' is running."
+                });
+                job.State = State.Error;
+                progressCallback?.Invoke(new ProgressState
+                {
+                    BackupName = job.Name,
+                    State = State.Error,
+                    Message = msg
+                });
+                return;
+            }
+
+            int processedFiles = 0;
 			long processedSize = 0;
 			int copiedFiles = 0;
 
 			foreach (var sourceFile in files)
 			{
-				var relativePath = Path.GetRelativePath(job.SourceDirectory, sourceFile);
+                if (!string.IsNullOrEmpty(BusinessSoftware) && Process.GetProcessesByName(BusinessSoftware).Length > 0)
+                {
+                    BackupManager.GetLogger().Log(new LogEntry
+                    {
+                        Level = Level.Warning,
+                        Message = $"Backup {job.Name} stopped: Business software '{BusinessSoftware}' detected during execution."
+                    });
+                    job.State = State.Error;
+                    break; 
+                }
+
+                var relativePath = Path.GetRelativePath(job.SourceDirectory, sourceFile);
 				var targetFile = Path.Combine(job.TargetDirectory, relativePath);
 				var targetDir = Path.GetDirectoryName(targetFile);
 
@@ -128,19 +157,22 @@ namespace EasySave.Backup
 				processedSize += fileSize;
 			}
 
-			// Final progress state
-			var finalState = new ProgressState
-			{
-				BackupName = job.Name,
-				State = State.Completed,
-				TotalFiles = totalFiles,
-				TotalSize = totalSize,
-				FilesRemaining = 0,
-				SizeRemaining = 0,
-				ProgressPercentage = 100
-			};
+            // Final progress state
+            if (job.State != State.Error)
+            {
+                var finalState = new ProgressState
+                {
+                    BackupName = job.Name,
+                    State = State.Completed,
+                    TotalFiles = totalFiles,
+                    TotalSize = totalSize,
+                    FilesRemaining = 0,
+                    SizeRemaining = 0,
+                    ProgressPercentage = 100
+                };
 
-			progressCallback?.Invoke(finalState);
+                progressCallback?.Invoke(finalState);
+            }
 		}
 	}
 }

--- a/EasySave/Backup/IBackupStrategy.cs
+++ b/EasySave/Backup/IBackupStrategy.cs
@@ -8,6 +8,6 @@ namespace EasySave.Backup
 		/// <summary>
 		/// Executes the backup strategy
 		/// </summary>
-		void Execute(BackupJob job, Action<ProgressState> progressCallback);
+		void Execute(BackupJob job, string BusinessSoftware, Action<ProgressState> progressCallback);
 	}
 }

--- a/EasySave/Backup/ProgressState.cs
+++ b/EasySave/Backup/ProgressState.cs
@@ -16,6 +16,8 @@ namespace EasySave.Backup
         public string CurrentTargetFile { get; set; }
         public double ProgressPercentage { get; set; }
 
+        public string Message { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the ProgressState class with default values.
         /// </summary>
@@ -29,6 +31,7 @@ namespace EasySave.Backup
             State             = State.Inactive;
             CurrentSourceFile = string.Empty;
             CurrentTargetFile = string.Empty;
+            Message = string.Empty;
         }
     }
 }

--- a/EasySave/default.json
+++ b/EasySave/default.json
@@ -2,5 +2,6 @@
 	"Version": "1.1.0",
 	"MaxBackupJobs": 5,
 	"UseBackupJobLimit": false,
-	"LoggerFormat": "text"
+	"LoggerFormat": "text",
+	"BusinessSoftware": "CalculatorApp"
 }


### PR DESCRIPTION
Ajoute la détection d'un logiciel métier (paramètre BusinessSoftware) pour bloquer ou interrompre automatiquement une sauvegarde si ce logiciel est en cours d'exécution. Affiche un message d'erreur à l'utilisateur, log l'événement, et propage l'état d'erreur via ProgressState. Modifie la signature des stratégies de sauvegarde pour inclure ce paramètre et adapte l'interface utilisateur pour afficher les messages d'état. Retourne un booléen de succès/échec lors de l'exécution d'un job.