### PR TITLE
Améliore gestion et affichage des statuts d'erreur/arrêt

### DIFF
--- a/EasySave/Backup/CompleteBackupStrategy.cs
+++ b/EasySave/Backup/CompleteBackupStrategy.cs
@@ -284,11 +284,20 @@ namespace EasySave.Backup
             // --- 6. Final State ---
             if (job.State != State.Error)
             {
-                progressCallback?.Invoke(new()
+                progressCallback?.Invoke(new ProgressState
                 {
                     BackupName = job.Name,
                     State = State.Completed,
                     ProgressPercentage = 100
+                });
+            }
+            else
+            {
+                progressCallback?.Invoke(new ProgressState
+                {
+                    BackupName = job.Name,
+                    State = State.Error,
+                    Message = "Stopped"
                 });
             }
         }

--- a/EasySave/Backup/DifferentialBackupStrategy.cs
+++ b/EasySave/Backup/DifferentialBackupStrategy.cs
@@ -1,6 +1,7 @@
 using EasyLog.Data;
 using EasyLog.Logging;
 using EasySave.Utils;
+using EasySave.View.Localization;
 using Newtonsoft.Json.Linq;
 using System.Diagnostics;
 
@@ -295,6 +296,15 @@ namespace EasySave.Backup
                     BackupName = job.Name,
                     State = State.Completed,
                     ProgressPercentage = 100
+                });
+            }
+            else
+            {
+                progressCallback?.Invoke(new ProgressState
+                {
+                    BackupName = job.Name,
+                    State = State.Error,
+                    Message = EasySave.View.Localization.I18n.Instance.GetString("status_stopped") ?? "Stopped by user"
                 });
             }
         }


### PR DESCRIPTION
Affichage des statuts d'erreur et d'arrêt rendu plus clair et cohérent dans l'UI. Suppression du préfixe "✗" sur les erreurs, ajout d'un statut "Stopped" localisé pour les jobs arrêtés, et utilisation de la localisation pour les messages de complétion. Le statut global affiche désormais "Backup Closed" si une erreur survient. Ces changements améliorent la lisibilité et l'internationalisation des statuts de sauvegarde.