### PR TITLE
Ajout copie CryptoSoft.dll et ajustements config

### DIFF
--- a/EasyGUI/EasyGUI.csproj
+++ b/EasyGUI/EasyGUI.csproj
@@ -42,6 +42,10 @@
 		<Copy SourceFiles="..\CryptoSoft\bin\$(Configuration)\net8.0\CryptoSoft.runtimeconfig.json"
 			  DestinationFolder="$(OutDir)"
 			  SkipUnchangedFiles="true" />
+
+		<Copy SourceFiles="..\CryptoSoft\bin\$(Configuration)\net8.0\CryptoSoft.dll"
+			  DestinationFolder="$(OutDir)"
+			  SkipUnchangedFiles="true" />
 	</Target>
 
 </Project>

--- a/EasyGUI/ViewModels/MainWindowViewModel.cs
+++ b/EasyGUI/ViewModels/MainWindowViewModel.cs
@@ -856,6 +856,10 @@ namespace EasyGUI.ViewModels
             // Load detailed settings (Feature Branch)
             ConfigBusinessSoftware = config.GetConfig<string>("BusinessSoftware") ?? "";
             ConfigCryptoPath = config.GetConfig<string>("CryptoSoftPath") ?? "";
+            if (string.IsNullOrWhiteSpace(ConfigCryptoPath))
+            {
+                ConfigCryptoPath = "CryptoSoft.exe";
+            }
             ConfigCryptoKey = config.GetConfig<string>("CryptoKey") ?? "";
             ConfigMaxSize = config.GetConfig<long?>("MaxParallelTransferSize") ?? 1000;
 

--- a/EasySave/Utils/ConfigurationManager.cs
+++ b/EasySave/Utils/ConfigurationManager.cs
@@ -33,12 +33,12 @@ namespace EasySave.Utils
 		/// runtime. Use dynamic member access to retrieve specific configuration values as needed.</remarks>
 		private readonly Dictionary<string, object> configValues;
 
-		private readonly List<string> readOnlyVariables = ["Version", "PriorityExtensions"];
+        private readonly List<string> readOnlyVariables = ["Version"];
 
-		/// <summary>
-		/// Indicates wether the configuration variables have been edited and are required to save.
-		/// </summary>
-		private bool isDirty = false;
+        /// <summary>
+        /// Indicates wether the configuration variables have been edited and are required to save.
+        /// </summary>
+        private bool isDirty = false;
 
 		/// <summary>
 		/// Initializes a new instance of the ConfigurationManager class using the specified configuration directory. Ensures


### PR DESCRIPTION
- Ajout de la copie automatique de CryptoSoft.dll dans le dossier de sortie via EasyGUI.csproj.
- Initialisation par défaut de CryptoSoftPath à "CryptoSoft.exe" si non défini dans MainWindowViewModel.
- "PriorityExtensions" n'est plus en lecture seule dans ConfigurationManager.